### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/tyutiniv950740/6fae0b00-e637-41ac-90cf-0d33327812dd/0c9de72c-464a-4f15-91b7-2f14fa2e3f36/_apis/work/boardbadge/0ff2f77e-8698-4069-b2f6-87bde6dea4fb)](https://dev.azure.com/tyutiniv950740/6fae0b00-e637-41ac-90cf-0d33327812dd/_boards/board/t/0c9de72c-464a-4f15-91b7-2f14fa2e3f36/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#4](https://dev.azure.com/tyutiniv950740/6fae0b00-e637-41ac-90cf-0d33327812dd/_workitems/edit/4). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.